### PR TITLE
fix(ios13): Fixing issue with changes to ASWebAuthenticationSession.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ in case of vulnerabilities.
 
 ## [Unreleased]
 
+## [2.0.1] - 2019-10-15
+### Fixed
+- **iOS:** Conform to the new iOS 13 API for ASWebAuthenticationSession. ASWebAuthenticationSession now requires a delegate that provides a display context for the authentication session. [#14](https://github.com/proyecto26/nativescript-inappbrowser/issues/14) 
+
 ## [2.0.0] - 2019-07-27
 ### Added
 - **Android:** Migrate to AndroidX by [@jdnichollsc](https://github.com/jdnichollsc) ([3e7ca9a](https://github.com/proyecto26/nativescript-inappbrowser/commit/3e7ca9a6f41f182a62b61435ef13c9c5fa043978)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/src/InAppBrowser.ios.ts
+++ b/src/InAppBrowser.ios.ts
@@ -56,7 +56,7 @@ const getTransitionStyle = function (styleKey: string) {
   return styles[styleKey] || UIModalTransitionStyle.CoverVertical;
 };
 
-const InAppBrowser = (<any>NSObject).extend({
+const classMembers = {
   redirectResolve: null,
   redirectReject: null,
   authSession: <SFAuthenticationSession | ASWebAuthenticationSession> null,
@@ -158,6 +158,9 @@ const InAppBrowser = (<any>NSObject).extend({
             self.flowDidFinish();
           }
         );
+        if(ios.MajorVersion >= 13) {
+          self.authSession.start();
+        }
         self.authSession.start();
       });
     }
@@ -184,6 +187,9 @@ const InAppBrowser = (<any>NSObject).extend({
     else {
       this.close();
     }
+  },
+  presentationAnchorForWebAuthenticationSession: function (session: ASWebAuthenticationSession): UIWindow {
+    return UIApplication.sharedApplication.keyWindow;
   },
   dismissWithoutAnimation(controller: SFSafariViewController): void {
     const transition = CATransition.animation();
@@ -229,8 +235,18 @@ const InAppBrowser = (<any>NSObject).extend({
     this.redirectReject = reject;
     return true;
   }
-}, {
-  protocols: [SFSafariViewControllerDelegate]
-});
+};
+
+const nativeSignatures =
+  ios.MajorVersion >= 13
+    ? {
+        protocols: [
+          SFSafariViewControllerDelegate,
+          ASWebAuthenticationPresentationContextProviding
+        ]
+      }
+    : { protocols: [SFSafariViewControllerDelegate] };
+
+const InAppBrowser = (<any>NSObject).extend(classMembers, nativeSignatures);
 
 export default InAppBrowser.new();

--- a/src/InAppBrowser.ios.ts
+++ b/src/InAppBrowser.ios.ts
@@ -159,7 +159,7 @@ const classMembers = {
           }
         );
         if(ios.MajorVersion >= 13) {
-          self.authSession.start();
+          self.authSession.presentationContextProvider = self;
         }
         self.authSession.start();
       });

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-inappbrowser",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-inappbrowser",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "InAppBrowser for NativeScript",
   "main": "InAppBrowser",
   "typings": "index.d.ts",

--- a/src/references.d.ts
+++ b/src/references.d.ts
@@ -1,3 +1,5 @@
 /// <reference path="./node_modules/tns-platform-declarations/ios.d.ts" />
 /// <reference path="./node_modules/tns-platform-declarations/android.d.ts" />
 /// <reference path="./types/android.d.ts" />
+/// <reference path="./types/ios.d.ts" />
+

--- a/src/types/ios.d.ts
+++ b/src/types/ios.d.ts
@@ -1,0 +1,36 @@
+interface ASWebAuthenticationPresentationContextProviding
+  extends NSObjectProtocol {
+  presentationAnchorForWebAuthenticationSession(
+    session: ASWebAuthenticationSession
+  ): UIWindow;
+}
+
+declare var ASWebAuthenticationPresentationContextProviding: {
+  prototype: ASWebAuthenticationPresentationContextProviding;
+};
+
+declare class ASWebAuthenticationSession extends NSObject {
+  static alloc(): ASWebAuthenticationSession; // inherited from NSObject
+
+  static new(): ASWebAuthenticationSession; // inherited from NSObject
+
+  prefersEphemeralWebBrowserSession: boolean;
+
+  presentationContextProvider: ASWebAuthenticationPresentationContextProviding;
+
+  constructor(o: {
+    URL: NSURL;
+    callbackURLScheme: string;
+    completionHandler: (p1: NSURL, p2: NSError) => void;
+  });
+
+  cancel(): void;
+
+  initWithURLCallbackURLSchemeCompletionHandler(
+    URL: NSURL,
+    callbackURLScheme: string,
+    completionHandler: (p1: NSURL, p2: NSError) => void
+  ): this;
+
+  start(): boolean;
+}


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Browser crashes on iOS 13 when openAuth is used.

## What is the new behavior?
Browser does not crash on iOS 13 when openAuth is used.

Fixes/Implements/Closes #14.

## Note
I had to add types/ios.d.ts to get Typescript to recognize the new APIs. You'll probably want to remove it once tns-platform-declarations is updated.
