### PR TITLE
Fix issue about headers option not working from Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ in case of vulnerabilities.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed issue about `headers` option not working from **Android** [#16](https://github.com/proyecto26/nativescript-inappbrowser/issues/16).
+
 ## [2.1.0] - 2019-11-13
 ### Added
 - Added support for `automatic` modal presentation style from **iOS**.

--- a/src/InAppBrowser.android.ts
+++ b/src/InAppBrowser.android.ts
@@ -95,7 +95,7 @@ class InAppBrowserModule extends java.lang.Object {
       return Promise.reject(new Error(InAppBrowserModule.ERROR_CODE));
     }
 
-    const options = getDefaultOptions(url, inAppBrowserOptions);
+    const options: InAppBrowserOptions = getDefaultOptions(url, inAppBrowserOptions);
 
     const builder = new CustomTabsIntent.Builder();
     if (options[InAppBrowserModule.KEY_TOOLBAR_COLOR]) {
@@ -131,7 +131,7 @@ class InAppBrowserModule extends java.lang.Object {
     const customTabsIntent = builder.build();
 
     const keyHeaders = options[InAppBrowserModule.KEY_HEADERS];
-    if (keyHeaders && keyHeaders.length) {
+    if (keyHeaders) {
       const headers = new Bundle();
       for (const key in keyHeaders) {
         if (keyHeaders.hasOwnProperty(key)) {

--- a/src/InAppBrowser.common.ts
+++ b/src/InAppBrowser.common.ts
@@ -24,14 +24,15 @@ export type RedirectResult = {
 
 export type AuthSessionResult = RedirectResult | BrowserResult;
 
-export function getDefaultOptions(url, options) {
+export function getDefaultOptions(url: string, options: any) {
   return {
     ...options,
     url,
     dismissButtonStyle: options.dismissButtonStyle || 'close',
-    readerMode: options.readerMode !== undefined ? options.readerMode : false,
+    readerMode: !!options.readerMode,
     animated: options.animated !== undefined ? options.animated : true,
-    modalEnabled: options.modalEnabled !== undefined ? options.modalEnabled : true
+    modalEnabled: options.modalEnabled !== undefined ? options.modalEnabled : true,
+    enableBarCollapsing: !!options.enableBarCollapsing
   };
 }
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
`headers` option not working from **Android** platform.

## What is the new behavior?
Apply the option by fixing the validation to get the keys of the headers.

Fixes/Implements/Closes [#16](https://github.com/proyecto26/nativescript-inappbrowser/issues/16).