### PR TITLE
Validate cancel type from auth redirection

### DIFF
--- a/src/InAppBrowser.common.ts
+++ b/src/InAppBrowser.common.ts
@@ -77,7 +77,7 @@ function _checkResultAndReturnUrl(
   result: AuthSessionResult
 ): Promise<AuthSessionResult> {
   return new Promise(function(resolve) {
-    if (android) {
+    if (android && result.type !== 'cancel') {
       android.once(
         AndroidApplication.activityResumedEvent,
         function(args: AndroidActivityEventData) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
It's required to validate the type of the auth redirection from Android to have the same behavior like iOS, right now we're always getting the last url.

## What is the new behavior?
Validate if the **type** of the auth result is different to `cancel` before to check the url of the last redirection.