### PR TITLE
Fix for NS 6.4.

### DIFF
--- a/src/platforms/ios/build.xcconfig
+++ b/src/platforms/ios/build.xcconfig
@@ -1,0 +1,1 @@
+OTHER_LDFLAGS = $(inherited) -framework "SafariServices"

--- a/src/platforms/ios/native-api-usage.json
+++ b/src/platforms/ios/native-api-usage.json
@@ -1,0 +1,3 @@
+{
+  "uses": ["SafariServices.*", "AuthenticationServices.*"]
+}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

(sorry!)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
For some reason, after upgrading to NS 6.4, the `SafariServices.framework` is not added to the project.

## What is the new behavior?
<!-- Describe the changes. -->
The change in `build.xcconfig` makes sure the `SafariServices.framework` is linked to the project. The change in `native-api-usage.json` whitelists the required classes, in case the project is using the Metadata whitelists functionality introduced in 6.4.

There are no breaking changes and existing users don't need to do anything about this.

