### PR TITLE
Fix wrong param passed to parseColor method

### DIFF
--- a/src/InAppBrowser.ios.ts
+++ b/src/InAppBrowser.ios.ts
@@ -105,7 +105,7 @@ function setup() {
             }
           }
           if (inAppBrowserOptions.preferredControlTintColor) {
-            const color = parseColor(inAppBrowserOptions.preferredBarTintColor);
+            const color = parseColor(inAppBrowserOptions.preferredControlTintColor);
             if (color) {
               this.safariVC.preferredControlTintColor = color.ios;
             }


### PR DESCRIPTION
After the `3.0.1` release, the `parserColor` method is getting the `preferredBarTintColor` instead of the `preferredControlTintColor` when setting the Control color option.

This is applying the same color for both the bar and controls, thus making it hard to read the text on iOS.