### PR TITLE
dont throw on activity will crash

### DIFF
--- a/src/InAppBrowser.android.ts
+++ b/src/InAppBrowser.android.ts
@@ -257,7 +257,7 @@ function setup() {
       BROWSER_ACTIVITY_EVENTS.off(DISMISSED_EVENT);
   
       if (!InAppBrowserModule.redirectResolve) {
-        throw new AssertionError();
+        return;
       }
       const browserEvent = <ChromeTabsEvent>event.object;
       InAppBrowserModule.redirectResolve({


### PR DESCRIPTION
In case we end up here and the promise already resolved dont throw or the app will crash with an error like this:
```
Activity {com.elichens.outdoorapp/com.proyecto26.inappbrowser.ChromeTabsManagerActivity} did not call through to super.onDestroy()
```
I am not exactly sure when this could happen but i got that error on sentry and for sure the error comes from here.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

